### PR TITLE
(fix/poster): Show a movie even when the poster is empty

### DIFF
--- a/mvw/main.py
+++ b/mvw/main.py
@@ -205,12 +205,11 @@ def interactive(title: str):
 
         movie: dict = movie_manager.fetch_movie_metadata(title=title)
         poster_path = movie_manager.fetch_poster()
-        poster_path = str(poster_path.resolve())
+        if poster_path == None:
+            poster_path = "N/A"
+        else:
+            poster_path = str(poster_path.resolve())
 
-        # from mvw.test import TestData
-        # test_data = TestData()
-        # movie = test_data.test_movie
-        # poster_path = test_data.test_poster
 
         movie_already_reviewed = database_manager.get_movie_metadata_by_title(movie['title'])
         already_reviewed = False


### PR DESCRIPTION
Hello, Fatinul. I am Lee Yunjin, who lives in South Korea, and I visited here via Reddit.
I hope you are having a good day. This winter is quite cold, so I wish you well.


I think this software is quite interesting, since I was recently influenced by my brother(he is a movie enthusiasts who has watched thousands of movies including b/w), I just searched some movies which were interesting.

Now, I am explaining what was actually happening on this problem:
First, Army of Shadows, by Jean-Pierre Melville was good with mvw.
However, I tested the case "The Color of Pomegranates" by Sergei Parajanov, which was released in 1969, Armenia, the problem was shown on my terminal.
Since this movie is old, and it is quite awkward to first-world residents like us, there is no poster on OMDB.
Also, there are many second-world movies that is released after few decades from release date in second world; in this case mvw will be broken with moai's error log.

I am suggesting this idea: Show a placeholder when there's no poster.
Missing poster is not that serious problem to check a movie's rating, so I think it is better to show available information if there's some.

I hope this patch may help you,
thank you.
